### PR TITLE
Rc sprint 25.08.001

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Core Framework Packages -->
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
@@ -16,7 +15,6 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="9.0.8" />
-
     <!-- Entity Framework Packages -->
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.8" />
@@ -24,36 +22,31 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.8" />
-
     <!-- System Packages -->
     <PackageVersion Include="System.Text.Json" Version="9.0.8" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-
     <!-- Source Linking -->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-
     <!-- Autofac Packages -->
     <PackageVersion Include="Autofac" Version="8.4.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="10.0.0" />
-
     <!-- Serilog Packages -->
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageVersion Include="Serilog.Extensions.Logging" Version="9.0.2" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.4" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="9.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
-
     <!-- Testing Packages -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageVersion Include="xunit" Version="2.6.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.0" />
-    <PackageVersion Include="NSubstitute" Version="5.1.0" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="NSubstitute" Version="5.3.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.6.0" />
   </ItemGroup>
 </Project>

--- a/GITFLOW.md
+++ b/GITFLOW.md
@@ -109,6 +109,7 @@ This creates the following aliases:
 - `git hotfix-start <version>` - Start a hotfix
 - `git hotfix-finish <version>` - Complete a hotfix
 - `git sync` - Sync main and develop branches
+- `git sync-develop` - Sync develop branch with main (after manual changes)
 - `git status-all` - Show comprehensive repository status
 
 ### Development Environment
@@ -528,6 +529,9 @@ git hotfix-finish 1.2.1
 ```bash
 # Sync all branches with remote
 git sync
+
+# Sync develop branch with main (after manual main branch updates)
+git sync-develop
 
 # Show comprehensive status
 git status-all
@@ -1094,6 +1098,38 @@ dotnet test --filter "FullyQualifiedName~YourTestClass.YourTestMethod"
 ```
 
 #### **Version and Release Issues**
+
+**Problem**: "Develop branch shows '1 commit behind main' after release"
+```bash
+# This is normal after merging develop to main
+# The merge commit on main needs to be pulled back to develop
+
+# Solution 1: Use the sync-develop alias (recommended)
+git sync-develop
+
+# Solution 2: Manual sync (equivalent to above)
+git checkout develop
+git pull origin main
+git push origin develop
+
+# Solution 3: If you made other changes to main manually
+# (e.g., documentation updates, hotfixes not through GitFlow)
+git checkout develop
+git pull origin develop  # Get latest develop first
+git merge origin/main     # Merge main changes to develop
+git push origin develop
+
+# Why this happens:
+# When develop merges to main, a merge commit is created on main
+# Develop branch doesn't automatically get this merge commit
+# This is expected GitFlow behavior - main and develop should stay in sync
+
+# Use cases for sync-develop:
+# - After manual releases
+# - After emergency hotfixes applied directly to main
+# - After documentation updates made to main
+# - After any manual changes to main branch
+```
 
 **Problem**: "Wrong version number generated"
 ```bash

--- a/docs/ComponentModelRegistration.md
+++ b/docs/ComponentModelRegistration.md
@@ -1,0 +1,473 @@
+# Component Model Attribute Registration
+
+This document explains how to use component model attributes for automatic service registration with Autofac in the Idevs.Foundation framework.
+
+## Overview
+
+The component model attributes provide a **declarative approach** to dependency injection registration, eliminating the need for manual service registration in container configuration. Simply decorate your classes with the appropriate lifetime attributes, and the `FoundationModule` will automatically discover and register them during container setup.
+
+## Key Benefits
+
+- ✅ **Declarative Registration**: Mark classes with attributes instead of manual container configuration
+- ✅ **Automatic Discovery**: Services are automatically discovered during assembly scanning
+- ✅ **Interface Registration**: Automatically registers as implemented interfaces (with fallback to self-registration)
+- ✅ **Lifetime Management**: Clear, type-safe lifetime specification
+- ✅ **Reduced Boilerplate**: No need to write container registration code for every service
+- ✅ **Consistent Conventions**: Uniform approach across the entire application
+
+## Available Attributes
+
+### `[Singleton]`
+Registers the service as a **singleton** - single instance for the entire application lifetime.
+- **Autofac Equivalent**: `.SingleInstance()`
+- **Use Case**: Expensive-to-create objects, stateless services, configuration objects
+
+### `[Scoped]`
+Registers the service as **scoped** - one instance per lifetime scope (typically per HTTP request in web applications).
+- **Autofac Equivalent**: `.InstancePerLifetimeScope()`
+- **Use Case**: Database contexts, repository patterns, request-specific services
+
+### `[Transient]`
+Registers the service as **transient** - new instance every time it's requested.
+- **Autofac Equivalent**: `.InstancePerDependency()`
+- **Use Case**: Lightweight services, stateless operations, factory patterns
+
+## Attribute Properties
+
+All component model attributes inherit from `ComponentModelAttribute` and support:
+
+### `AsSelf` Property
+- **Type**: `bool`
+- **Default**: `false`
+- **Description**: Controls registration behavior
+  - `false` (default): Registers as implemented interfaces (with fallback to self if no interfaces)
+  - `true`: Forces registration as the concrete implementation type
+
+### `Lifetime` Property
+- **Type**: `ServiceLifetime`
+- **Description**: Automatically set by the specific attribute (read-only in practice)
+
+## Registration Logic
+
+### Interface vs Self Registration
+
+```csharp
+// Default behavior (AsSelf = false)
+[Scoped]
+public class UserService : IUserService  // → Registered as IUserService
+
+[Scoped] 
+public class EmailHelper                  // → Registered as EmailHelper (no interfaces)
+
+// Explicit self registration (AsSelf = true)
+[Scoped(AsSelf = true)]
+public class UserService : IUserService  // → Registered as UserService (concrete type)
+```
+
+## Usage Examples
+
+### Basic Service Registration
+
+```csharp
+using Idevs.Foundation.Autofac.ComponentModels;
+
+// Singleton service - expensive to create, shared state
+[Singleton]
+public class ConfigurationService : IConfigurationService
+{
+    public string ConnectionString { get; }
+    
+    public ConfigurationService(IConfiguration config)
+    {
+        ConnectionString = config.GetConnectionString("DefaultConnection");
+    }
+}
+
+// Scoped service - per-request lifetime in web apps
+[Scoped]
+public class OrderService : IOrderService
+{
+    private readonly IRepository<Order> _orderRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    
+    public OrderService(IRepository<Order> orderRepository, IUnitOfWork unitOfWork)
+    {
+        _orderRepository = orderRepository;
+        _unitOfWork = unitOfWork;
+    }
+}
+
+// Transient service - lightweight, stateless
+[Transient]
+public class EmailValidator : IEmailValidator
+{
+    public bool IsValidEmail(string email)
+    {
+        return !string.IsNullOrEmpty(email) && email.Contains("@");
+    }
+}
+```
+
+### Advanced Registration Scenarios
+
+```csharp
+// Multiple interface implementation
+[Scoped]
+public class NotificationService : IEmailNotificationService, ISmsNotificationService
+{
+    // Registered as both IEmailNotificationService AND ISmsNotificationService
+}
+
+// Self registration for concrete type injection
+[Singleton(AsSelf = true)]
+public class CacheManager : ICacheManager
+{
+    // Registered as CacheManager (concrete type)
+    // Useful when you need to inject the concrete implementation
+}
+
+// No interfaces - automatic self registration
+[Scoped]
+public class InternalHelper  // No interfaces
+{
+    // Automatically registered as InternalHelper
+}
+```
+
+### Repository Pattern Example
+
+```csharp
+// Base repository interface
+public interface IRepository<T> where T : class
+{
+    Task<T> GetByIdAsync(int id);
+    Task<IEnumerable<T>> GetAllAsync();
+    Task AddAsync(T entity);
+    Task UpdateAsync(T entity);
+    Task DeleteAsync(int id);
+}
+
+// Generic repository implementation
+[Scoped]
+public class Repository<T> : IRepository<T> where T : class
+{
+    private readonly DbContext _context;
+    
+    public Repository(DbContext context)
+    {
+        _context = context;
+    }
+    
+    // Implementation...
+}
+
+// Specific repository with additional methods
+[Scoped]
+public class UserRepository : Repository<User>, IUserRepository
+{
+    public UserRepository(DbContext context) : base(context) { }
+    
+    public async Task<User> GetByEmailAsync(string email)
+    {
+        // Custom implementation
+    }
+}
+```
+
+### CQRS Handler Registration
+
+```csharp
+using Idevs.Foundation.Cqrs.Commands;
+using Idevs.Foundation.Cqrs.Queries;
+
+// Command handlers are automatically registered as scoped
+[Scoped]
+public class CreateUserCommandHandler : ICommandHandler<CreateUserCommand, User>
+{
+    private readonly IUserRepository _userRepository;
+    
+    public CreateUserCommandHandler(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+    
+    public async Task<User> Handle(CreateUserCommand command, CancellationToken cancellationToken)
+    {
+        // Implementation
+    }
+}
+
+// Query handlers
+[Scoped]
+public class GetUsersQueryHandler : IQueryHandler<GetUsersQuery, IEnumerable<User>>
+{
+    private readonly IUserRepository _userRepository;
+    
+    public GetUsersQueryHandler(IUserRepository userRepository)
+    {
+        _userRepository = userRepository;
+    }
+    
+    public async Task<IEnumerable<User>> Handle(GetUsersQuery query, CancellationToken cancellationToken)
+    {
+        // Implementation
+    }
+}
+```
+
+## Container Setup
+
+### Basic Setup
+
+```csharp
+using Autofac;
+using Idevs.Foundation.Autofac.Extensions;
+using System.Reflection;
+
+// Program.cs or Startup.cs
+var builder = new ContainerBuilder();
+
+// Register Foundation with current assembly
+builder.RegisterFoundation();
+
+// Or specify specific assemblies
+builder.RegisterFoundation(
+    Assembly.GetExecutingAssembly(),
+    Assembly.GetAssembly(typeof(SomeServiceInAnotherAssembly))
+);
+
+var container = builder.Build();
+```
+
+### ASP.NET Core Integration
+
+```csharp
+// Program.cs (ASP.NET Core 6+)
+using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Idevs.Foundation.Autofac.Extensions;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// Replace default DI container with Autofac
+builder.Host.UseServiceProviderFactory(new AutofacServiceProviderFactory());
+
+builder.Host.ConfigureContainer<ContainerBuilder>(containerBuilder =>
+{
+    // Register Foundation components (includes component model scanning)
+    containerBuilder.RegisterFoundation(
+        Assembly.GetExecutingAssembly(),
+        // Add other assemblies as needed
+        typeof(SomeService).Assembly
+    );
+    
+    // Optional: Register with Serilog logging
+    containerBuilder.RegisterFoundationWithSerilog(
+        builder.Configuration,
+        Assembly.GetExecutingAssembly()
+    );
+});
+
+var app = builder.Build();
+```
+
+### Multi-Assembly Registration
+
+```csharp
+var assemblies = new[]
+{
+    Assembly.GetExecutingAssembly(),              // Current assembly
+    typeof(UserService).Assembly,                 // Services assembly
+    typeof(UserRepository).Assembly,              // Data assembly
+    typeof(CreateUserCommandHandler).Assembly     // Handlers assembly
+};
+
+builder.RegisterFoundation(assemblies);
+```
+
+## Best Practices
+
+### 1. Choose Appropriate Lifetimes
+
+```csharp
+// ✅ Good: Configuration as singleton
+[Singleton]
+public class AppConfiguration : IAppConfiguration { }
+
+// ✅ Good: Database context as scoped
+[Scoped]
+public class ApplicationDbContext : DbContext { }
+
+// ✅ Good: Lightweight validator as transient
+[Transient]
+public class EmailValidator : IEmailValidator { }
+
+// ❌ Avoid: Database context as singleton (causes issues with EF Core)
+// [Singleton]
+// public class ApplicationDbContext : DbContext { }
+```
+
+### 2. Interface Design
+
+```csharp
+// ✅ Good: Clear interface contract
+public interface IUserService
+{
+    Task<User> GetUserAsync(int id);
+    Task<User> CreateUserAsync(CreateUserRequest request);
+}
+
+[Scoped]
+public class UserService : IUserService
+{
+    // Implementation
+}
+
+// ✅ Good: Multiple interfaces for different contracts
+[Scoped]
+public class NotificationService : IEmailService, INotificationService
+{
+    // Registered as both interfaces
+}
+```
+
+### 3. Avoid Circular Dependencies
+
+```csharp
+// ❌ Bad: Circular dependency
+[Scoped] public class ServiceA : IServiceA
+{
+    public ServiceA(IServiceB serviceB) { }
+}
+
+[Scoped] public class ServiceB : IServiceB  
+{
+    public ServiceB(IServiceA serviceA) { } // Circular!
+}
+
+// ✅ Good: Use mediator or event-driven approach
+[Scoped] public class ServiceA : IServiceA
+{
+    public ServiceA(IMediator mediator) { }
+}
+
+[Scoped] public class ServiceB : IServiceB
+{
+    public ServiceB(IMediator mediator) { }
+}
+```
+
+### 4. Testing Considerations
+
+```csharp
+// ✅ Good: Design for testability
+public interface IEmailService
+{
+    Task SendEmailAsync(string to, string subject, string body);
+}
+
+[Scoped]
+public class EmailService : IEmailService
+{
+    // Can be easily mocked in tests
+}
+
+// In tests:
+var mockEmailService = new Mock<IEmailService>();
+// Setup and verify mock behavior
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### 1. Service Not Found
+```
+Autofac.Core.Registration.ComponentNotRegisteredException: 
+The requested service 'MyService' has not been registered.
+```
+
+**Solutions:**
+- Ensure the service class has a component model attribute
+- Verify the assembly containing the service is included in `RegisterFoundation()`
+- Check that the service class is `public` and not `abstract`
+
+#### 2. Missing Interface Registration
+```
+The requested service 'IMyService' has not been registered.
+```
+
+**Solutions:**
+- Ensure your service class implements the interface
+- Verify the interface is `public`
+- Consider using `AsSelf = true` if you need concrete type registration
+
+#### 3. Wrong Lifetime Behavior
+
+**Problem**: Service instances aren't behaving as expected
+
+**Solutions:**
+- Review lifetime attribute choice ([Singleton] vs [Scoped] vs [Transient])
+- Understand the scope context (web request, background service, etc.)
+- Avoid capturing scoped services in singletons
+
+### Debugging Registration
+
+```csharp
+// Enable detailed Autofac logging to see registrations
+var builder = new ContainerBuilder();
+builder.RegisterFoundation(Assembly.GetExecutingAssembly());
+
+var container = builder.Build();
+
+// In development, you can inspect registrations
+foreach (var registration in container.ComponentRegistry.Registrations)
+{
+    Console.WriteLine($"Registered: {registration.Activator.LimitType.Name}");
+    foreach (var service in registration.Services)
+    {
+        Console.WriteLine($"  As: {service.Description}");
+    }
+}
+```
+
+## Migration from Manual Registration
+
+### Before (Manual Registration)
+```csharp
+// Old approach - manual registration
+builder.RegisterType<UserService>().As<IUserService>().InstancePerLifetimeScope();
+builder.RegisterType<EmailService>().As<IEmailService>().InstancePerLifetimeScope();
+builder.RegisterType<OrderService>().As<IOrderService>().InstancePerLifetimeScope();
+// ... dozens more registrations
+```
+
+### After (Attribute-Based Registration)
+```csharp
+// New approach - attribute-based
+[Scoped] public class UserService : IUserService { }
+[Scoped] public class EmailService : IEmailService { }
+[Scoped] public class OrderService : IOrderService { }
+
+// Single registration call
+builder.RegisterFoundation(Assembly.GetExecutingAssembly());
+```
+
+## Performance Considerations
+
+- **Assembly Scanning**: Occurs once during container build, minimal runtime impact
+- **Reflection Overhead**: Attribute discovery uses efficient caching
+- **Registration Performance**: Equivalent to manual registration after container build
+- **Memory Usage**: Negligible overhead compared to manual registration
+
+## Summary
+
+Component Model Attributes provide a clean, maintainable approach to dependency injection in Autofac-based applications. By decorating your service classes with `[Singleton]`, `[Scoped]`, or `[Transient]` attributes, you can:
+
+- Eliminate boilerplate container configuration code
+- Ensure consistent lifetime management
+- Improve code readability and maintainability  
+- Reduce registration errors and omissions
+- Support automatic interface registration with sensible fallbacks
+
+The system automatically handles interface detection, lifetime management, and registration during the `RegisterFoundation()` call, making dependency injection configuration both simpler and more reliable.

--- a/src/Idevs.Foundation.Autofac/ComponentModels/ComponentModelAttribute.cs
+++ b/src/Idevs.Foundation.Autofac/ComponentModels/ComponentModelAttribute.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Idevs.Foundation.Autofac.ComponentModels;
+
+/// <summary>
+/// Base attribute for component model registration.
+/// </summary>
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+public abstract class ComponentModelAttribute(
+    ServiceLifetime lifetime = ServiceLifetime.Transient,
+    bool asSelf = false
+) : Attribute
+{
+    /// <summary>
+    /// Gets a value indicating whether to register as self (implementation type).
+    /// </summary>
+    public bool AsSelf { get; set; } = asSelf;
+
+    /// <summary>
+    /// Gets or sets the lifetime of the service.
+    /// </summary>
+    public ServiceLifetime Lifetime { get; set; } = lifetime;
+}

--- a/src/Idevs.Foundation.Autofac/ComponentModels/ScopedAttribute.cs
+++ b/src/Idevs.Foundation.Autofac/ComponentModels/ScopedAttribute.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Idevs.Foundation.Autofac.ComponentModels;
+
+/// <summary>
+/// Marks a class for automatic registration as scoped (instance per lifetime scope) in the Autofac container.
+/// </summary>
+public sealed class ScopedAttribute() : ComponentModelAttribute(lifetime: ServiceLifetime.Scoped)
+{
+}

--- a/src/Idevs.Foundation.Autofac/ComponentModels/SingletonAttribute.cs
+++ b/src/Idevs.Foundation.Autofac/ComponentModels/SingletonAttribute.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Idevs.Foundation.Autofac.ComponentModels;
+
+/// <summary>
+/// Marks a class for automatic registration as a singleton in the Autofac container.
+/// </summary>
+public sealed class SingletonAttribute() : ComponentModelAttribute(lifetime: ServiceLifetime.Singleton)
+{
+}

--- a/src/Idevs.Foundation.Autofac/ComponentModels/TransientAttribute.cs
+++ b/src/Idevs.Foundation.Autofac/ComponentModels/TransientAttribute.cs
@@ -1,0 +1,10 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Idevs.Foundation.Autofac.ComponentModels;
+
+/// <summary>
+/// Marks a class for automatic registration as transient (instance per dependency) in the Autofac container.
+/// </summary>
+public sealed class TransientAttribute() : ComponentModelAttribute(lifetime: ServiceLifetime.Transient)
+{
+}


### PR DESCRIPTION
This pull request introduces a new attribute-based mechanism for automatic service registration in the Autofac container, making it easier to register classes as singletons, scoped, or transient services. It also updates several package versions and improves documentation for GitFlow operations, especially around syncing branches after releases or manual changes.

### Autofac Component Model Registration

* Added new base attribute `ComponentModelAttribute` and derived attributes (`SingletonAttribute`, `ScopedAttribute`, `TransientAttribute`) in the `Idevs.Foundation.Autofac.ComponentModels` namespace to mark classes for automatic registration with specified lifetimes. [[1]](diffhunk://#diff-8cccfc23f0acf563db1ebc627fd2fd6c695227d8b8a637f4d993c861fe7c9602R1-R23) [[2]](diffhunk://#diff-35baeb5cd096f071886c443a84a7aa6a0f3d9a7295c0a6ecaa77b8097fdc3ad2R1-R10) [[3]](diffhunk://#diff-cfed81bbd2ee5cbc714b617d4576cff9e4e87ea844f82f9b0c2c99d6733c5dc2R1-R10) [[4]](diffhunk://#diff-be743c08f6dcec990a1864dc2805aa58e04e5b23c77b2d313adde35dd1884646R1-R10)
* Updated `FoundationModule` to scan assemblies for these attributes and register marked types with Autofac using the correct lifetime and registration mode (as self or as implemented interfaces). [[1]](diffhunk://#diff-dfda74e2fa74c6ab0ae51f605ee1b500686f3f8d119ae848263f0de691c2f665R3-R4) [[2]](diffhunk://#diff-dfda74e2fa74c6ab0ae51f605ee1b500686f3f8d119ae848263f0de691c2f665R80-R142)

### Package Version Updates

* Updated several NuGet package versions in `Directory.Packages.props`, including test frameworks (`xunit`, `Microsoft.NET.Test.Sdk`, etc.) and logging packages (`Serilog.Settings.Configuration`, `FluentAssertions`, etc.), ensuring compatibility and security.

### GitFlow Documentation Improvements

* Added documentation and usage instructions for the new `git sync-develop` alias, clarifying how to sync the develop branch with main after releases or manual changes. [[1]](diffhunk://#diff-63f8c311dab8a34672bbc80fdd9a38fc599ffa8f1183a81dca5941f85f1b1d97R112) [[2]](diffhunk://#diff-63f8c311dab8a34672bbc80fdd9a38fc599ffa8f1183a81dca5941f85f1b1d97R533-R535)
* Provided detailed troubleshooting steps for resolving "develop branch is behind main" issues after releases, including recommended and manual solutions.